### PR TITLE
Added missing 'zlib' dependency for 'libprotobuf'

### DIFF
--- a/pages/argOS/library-ports.md
+++ b/pages/argOS/library-ports.md
@@ -31,6 +31,7 @@ cd <genode-dir>
 # for libprotobuf
 ./tool/ports/prepare_port libc
 ./tool/ports/prepare_port stdcxx
+./tool/ports/prepare_port zlib
 # for libmosquitto
 ./tool/ports/prepare_port libc
 ./tool/ports/prepare_port stdcxx


### PR DESCRIPTION
In the documentation, there was 'zlib' library missing for building 'libprotobuf'.